### PR TITLE
Set python interpreter path for app/ai

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     }
   ],
   "prisma-smart-formatter.typescriptreact.defaultFormatter": "esbenp.prettier-vscode",
-  "prisma-smart-formatter.prisma.defaultFormatter": "Prisma.prisma"
+  "prisma-smart-formatter.prisma.defaultFormatter": "Prisma.prisma",
+  "python.defaultInterpreterPath": "/workspace/apps/ai/.venv/bin/python"
 }


### PR DESCRIPTION
Add `python.defaultInterpreterPath` to `.vscode/settings.json` to configure the default Python interpreter for the `apps/ai` project.

---
<a href="https://cursor.com/background-agent?bcId=bc-c32d9f7f-3833-4dd8-a708-104439b4c031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c32d9f7f-3833-4dd8-a708-104439b4c031">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

